### PR TITLE
Document All Existing Code

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -14,3 +14,5 @@ indent_style = space
 indent_size = 2
 indent_style = space
 
+[*.md]
+trim_trailing_whitespace = false

--- a/.github/workflows/automerge.yml
+++ b/.github/workflows/automerge.yml
@@ -28,7 +28,6 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           MERGE_LABELS: automerge,!work-in-progress
-          MERGE_REMOVE_LABELS: automerge
           MERGE_METHOD: rebase
           MERGE_FORKS: "false"
           UPDATE_METHOD: rebase

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,0 +1,25 @@
+name: GitHub Pages
+
+on:
+  push:
+    branches:
+      - master
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+      - uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          components: rustdoc
+      - name: Build
+        run: cargo doc --document-private-items
+      - name: Deploy
+        uses: peaceiris/actions-gh-pages@v3
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./target/doc

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -12,24 +12,36 @@ jobs:
     runs-on: ${{ matrix.os }}
 
     steps:
-      - name: Set up a Rust toolchain
-        uses: hecrj/setup-rust-action@v1.3.1
-        with:
-          rust-version: ${{ matrix.rust }}
-          components: clippy,rustfmt
       - uses: actions/checkout@v2
-      - name: Checkout submodules
-        shell: bash
-        run: |
-          git config --global url."https://github.com/".insteadOf "git@github.com:"
-          auth_header="$(git config --local --get http.https://github.com/.extraheader)"
-          git submodule sync --recursive
-          git -c "http.extraheader=$auth_header" -c protocol.version=2 submodule update --init --force --recursive --depth=1
-      - name: Lint
-        run: cargo clippy --all-features --all-targets -- -D warnings
+        with:
+          submodules: true
+          fetch-depth: 0
+      - name: Set up a Rust toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: ${{ matrix.rust }}
+          components: clippy, rustfmt
+      - name: Check
+        uses: actions-rs/cargo@v1
+        with:
+          command: check
       - name: Format
-        run: cargo fmt -- --check
-      - name: Build
-        run: cargo build --all-targets --verbose
+        uses: actions-rs/cargo@v1
+        with:
+          command: fmt
+          args: --check
+      - name: Lint
+        uses: actions-rs/clippy-check@v1
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          args: --all-features --all-targets -- -D warnings
       - name: Test
-        run: cargo test --verbose
+        uses: actions-rs/cargo@v1
+        with:
+          command: test
+          args: --verbose
+      - name: Build
+        uses: actions-rs/cargo@v1
+        with:
+          command: build
+          args: --all-targets --verbose --release

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -34,7 +34,7 @@ jobs:
         uses: actions-rs/clippy-check@v1
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
-          args: --all-features --all-targets -- -D warnings
+          args: --all-features --all-targets
       - name: Test
         uses: actions-rs/cargo@v1
         with:

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -29,7 +29,7 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: fmt
-          args: --check
+          args: -- --check
       - name: Lint
         uses: actions-rs/clippy-check@v1
         with:

--- a/ferroboy/src/assembly.rs
+++ b/ferroboy/src/assembly.rs
@@ -16,7 +16,7 @@ impl std::fmt::Display for AssemblyInstruction {
         }
 
         if let Some(arg) = &self.args[1] {
-            write!(f, " {}", arg)?;
+            write!(f, ",{}", arg)?;
         }
 
         Ok(())
@@ -165,6 +165,6 @@ mod tests {
         let res = TestOperation(Register::A, Register::D).disassemble(&State::default());
 
         assert!(res.is_ok());
-        assert_eq!("TEST A D", res.unwrap().to_string());
+        assert_eq!("TEST A,D", res.unwrap().to_string());
     }
 }

--- a/ferroboy/src/assembly.rs
+++ b/ferroboy/src/assembly.rs
@@ -2,6 +2,9 @@ use core::convert::TryInto;
 
 use crate::state::State;
 
+/// A raw 6502 assembly instruction.
+///
+/// This is mostly available for introspection and disassembly.
 pub struct AssemblyInstruction {
     command: String,
     args: [Option<String>; 2],

--- a/ferroboy/src/lib.rs
+++ b/ferroboy/src/lib.rs
@@ -15,6 +15,7 @@ mod system;
 
 pub type Result<T> = core::result::Result<T, String>;
 
+/// Prepare the system and start the emulation.
 pub fn start(state: &mut State) -> Result<()> {
     if let Some(_cart) = &state.cartridge {
         return state
@@ -26,6 +27,10 @@ pub fn start(state: &mut State) -> Result<()> {
     Err("Cartridge not loaded!".into())
 }
 
+/// Step the emulation.
+///
+/// In an ideal world, this should be done at the clock rate of the Gameboy, but technically
+/// can be done at any rate.
 pub fn tick(state: &mut State) -> Result<&'static dyn crate::operations::Operation> {
     let address = state.cpu.get16(Register::PC)?;
     let opcode = state.mmu[address];

--- a/ferroboy/src/operations/add8.rs
+++ b/ferroboy/src/operations/add8.rs
@@ -71,6 +71,16 @@ mod tests {
     use super::*;
 
     #[test]
+    fn it_disassembles_correctly() {
+        use core::convert::TryInto;
+
+        let add = Add8Operation(Register::A, Register::B);
+        let add_instruction: AssemblyInstruction = add.try_into().unwrap();
+
+        assert_eq!("ADD A,B", add_instruction.to_string());
+    }
+
+    #[test]
     fn it_adds_two_registers() -> crate::Result<()> {
         let mut state = State::default();
         state.cpu.set(Register::A, 0x10)?;

--- a/ferroboy/src/operations/add8.rs
+++ b/ferroboy/src/operations/add8.rs
@@ -3,6 +3,35 @@ use crate::operations::Operation;
 use crate::state::State;
 use crate::system::{Flags, Register};
 
+/// Add the contents of one register to another
+///
+/// # Opcode Reference
+/// ## Assembly definition
+/// ```a
+/// ADD A,B
+/// ```
+/// ## Runtime
+/// | Metric | Size |
+/// |:-------|:-----|
+/// | Length | 1 |
+/// | Cycles | 4 |
+///
+/// ## Flags
+/// | Flag | Value |
+/// |:-----|:------|
+/// | Zero | Set |
+/// | Subtract | 0 |
+/// | Half-Carry | Set |
+/// | Carry | Set |
+///
+/// # Examples
+/// ```rs
+/// let operation = Add8Operation(Register::A, Register::B);
+/// operation.act(&mut state).unwrap();
+/// ```
+///
+/// # Errors
+/// - The operation may fail if a 16-bit register is provided for either argument.
 #[derive(Debug)]
 pub struct Add8Operation(pub Register, pub Register);
 
@@ -11,6 +40,8 @@ impl Operation for Add8Operation {
         let value = state.cpu.get(self.1)?;
 
         state.cpu.clear_flag(Flags::SUBTRACTION);
+
+        // FIXME: This probably shouldn't ever fail, revisit this
         state.cpu.mutate(self.0, |old| old + value)?;
 
         // TODO: H + C
@@ -32,5 +63,72 @@ impl core::convert::TryFrom<Add8Operation> for AssemblyInstruction {
             .build()?;
 
         Ok(instruction)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn it_adds_two_registers() -> crate::Result<()> {
+        let mut state = State::default();
+        state.cpu.set(Register::A, 0x10)?;
+        state.cpu.set(Register::B, 0x06)?;
+
+        Add8Operation(Register::A, Register::B).act(&mut state)
+    }
+
+    #[test]
+    fn it_clears_the_zero_flag() {
+        use crate::system::Flags;
+
+        let mut state = State::default();
+        state.cpu.set_flag(Flags::SUBTRACTION);
+
+        Add8Operation(Register::A, Register::B)
+            .act(&mut state)
+            .unwrap();
+
+        assert_eq!(false, state.cpu.has_flag(Flags::SUBTRACTION))
+    }
+
+    #[test]
+    #[should_panic]
+    fn it_sets_the_half_carry_flag() {
+        todo!();
+    }
+
+    #[test]
+    #[should_panic]
+    fn it_sets_the_carry_flag() {
+        todo!();
+    }
+
+    #[test]
+    #[should_panic]
+    fn it_sets_the_zero_flag() {
+        todo!();
+    }
+
+    #[test]
+    fn it_returns_an_error_for_16bit_registers() {
+        let mut state = State::default();
+        state.cpu.set(Register::A, 0x10).unwrap();
+        state.cpu.set(Register::B, 0x06).unwrap();
+
+        assert!(
+            Add8Operation(Register::AF, Register::B)
+                .act(&mut state)
+                .is_err(),
+            "Add8Operation shouldn't accept left-hand 16-bit registers"
+        );
+
+        assert!(
+            Add8Operation(Register::B, Register::AF)
+                .act(&mut state)
+                .is_err(),
+            "Add8Operation shouldn't accept right-hand 16-bit registers"
+        );
     }
 }

--- a/ferroboy/src/operations/add8.rs
+++ b/ferroboy/src/operations/add8.rs
@@ -20,7 +20,7 @@ use crate::system::{Flags, Register};
 /// | Flag | Value |
 /// |:-----|:------|
 /// | Zero | Set |
-/// | Subtract | 0 |
+/// | Subtraction | 0 |
 /// | Half-Carry | Set |
 /// | Carry | Set |
 ///

--- a/ferroboy/src/operations/inc16.rs
+++ b/ferroboy/src/operations/inc16.rs
@@ -1,9 +1,39 @@
+use crate::assembly::{AssemblyInstruction, AssemblyInstructionBuilder};
 use crate::operations::Operation;
 use crate::state::State;
 use crate::system::{Flags, Register};
 
-/// Increments a singular 16bit register.
-/// Does not affect flags.
+// FIXME: WideRegiser
+/// Increments a singular register.
+///
+/// # Opcode Reference
+/// ## Assembly Definition
+/// ```a
+/// INC BC
+/// ```
+///
+/// ## Runtime
+/// | Metric | Size |
+/// |:-------|:-----|
+/// | Length | 1 |
+/// | Cycles | 8 |
+///
+/// ## Flags
+/// | Flag | Value |
+/// |:-----|:------|
+/// | Zero | Not Affected |
+/// | Subtraction | Not Affected |
+/// | Half-Carry | Not Affected |
+/// | Carry | Not Affected |
+///
+/// # Examples
+/// ```rs
+/// let operation = Inc16Operation(Register::BC);
+/// operation.act(&mut state).unwrap();
+/// ```
+///
+/// # Errors
+/// - The operation may fail if an 8-bit register is provided.
 #[derive(Debug)]
 pub struct Inc16Operation(pub Register);
 
@@ -35,6 +65,17 @@ impl Operation for Inc16Operation {
         state.cpu.increment_clock(8);
 
         Ok(())
+    }
+}
+
+impl core::convert::TryFrom<Inc16Operation> for AssemblyInstruction {
+    type Error = String;
+
+    fn try_from(value: Inc16Operation) -> Result<AssemblyInstruction, Self::Error> {
+        AssemblyInstructionBuilder::new()
+            .with_command("INC")
+            .with_arg(value.0)
+            .build()
     }
 }
 

--- a/ferroboy/src/operations/inc16.rs
+++ b/ferroboy/src/operations/inc16.rs
@@ -84,6 +84,16 @@ mod tests {
     use super::*;
 
     #[test]
+    fn it_disassembles_correctly() {
+        use core::convert::TryInto;
+
+        let inc = Inc16Operation(Register::BC);
+        let inc_instruction: AssemblyInstruction = inc.try_into().unwrap();
+
+        assert_eq!("INC BC", inc_instruction.to_string());
+    }
+
+    #[test]
     fn it_increments_the_lower_byte() {
         let mut state = State::default();
         let op = Inc16Operation(Register::BC);

--- a/ferroboy/src/operations/inc16.rs
+++ b/ferroboy/src/operations/inc16.rs
@@ -3,7 +3,7 @@ use crate::operations::Operation;
 use crate::state::State;
 use crate::system::{Flags, Register};
 
-// FIXME: WideRegiser
+// FIXME: WideRegister
 /// Increments a singular register.
 ///
 /// # Opcode Reference

--- a/ferroboy/src/operations/inc8.rs
+++ b/ferroboy/src/operations/inc8.rs
@@ -1,9 +1,38 @@
+use crate::assembly::{AssemblyInstruction, AssemblyInstructionBuilder};
 use crate::operations::Operation;
 use crate::state::State;
 use crate::system::Register;
 
-/// Increments a single 8bit register.
-/// Does not affect flags.
+/// Increments a single register.
+///
+/// # Opcode Reference
+/// ## Assembly definition
+/// ```a
+/// INC A
+/// ```
+///
+/// ## Runtime
+/// | Metric | Size |
+/// |:-------|:-----|
+/// | Length | 1 |
+/// | Cycles | 4 |
+///
+/// ## Flags
+/// | Flag | Value |
+/// |:-----|:------|
+/// | Zero | Set |
+/// | Subtraction | 0 |
+/// | Half-Carry | Set |
+/// | Carry | Not Affected |
+///
+/// # Examples
+/// ```rs
+/// let operation = Inc8Operation(Register::A);
+/// operation.act(&mut state).unwrap();
+/// ```
+///
+/// # Errors
+/// - The operation may fail if a 16-bit register is provided.
 #[derive(Debug)]
 pub struct Inc8Operation(pub Register);
 
@@ -12,9 +41,44 @@ impl Operation for Inc8Operation {
         let mut temp = u16::from(state.cpu.get(self.0)?);
         temp += 1;
 
+        // FIXME: Set flags as needed
         state.cpu.set(self.0, temp as u8)?;
         state.cpu.increment_clock(4);
 
         Ok(())
+    }
+}
+
+impl core::convert::TryFrom<Inc8Operation> for AssemblyInstruction {
+    type Error = String;
+
+    fn try_from(value: Inc8Operation) -> Result<AssemblyInstruction, Self::Error> {
+        AssemblyInstructionBuilder::new()
+            .with_command("INC")
+            .with_arg(value.0)
+            .build()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn it_increments_the_register() {
+        let mut state = State::default();
+
+        Inc8Operation(Register::A).act(&mut state).unwrap();
+
+        assert_eq!(1, state.cpu.get(Register::A).unwrap());
+    }
+
+    #[test]
+    fn it_disassembles_correctly() {
+        use core::convert::TryInto;
+        let assembly_instruction: AssemblyInstruction =
+            Inc8Operation(Register::A).try_into().unwrap();
+
+        assert_eq!("INC A", assembly_instruction.to_string());
     }
 }

--- a/ferroboy/src/operations/load16.rs
+++ b/ferroboy/src/operations/load16.rs
@@ -3,6 +3,35 @@ use crate::operations::Operation;
 use crate::state::State;
 use crate::system::Register;
 
+/// Loads an immediate 16-bit value into a register.
+///
+/// # Opcode Reference
+/// ## Assembly definition
+/// ```a
+/// LD BC,##
+/// ```
+///
+/// ## Runtime
+/// | Metric | Size |
+/// |:-------|:-----|
+/// | Length | 3    |
+/// | Cycles | 12   |
+///
+/// ## Flags
+/// | Flag          | Value        |
+/// |:--------------|:-------------|
+/// | Zero          | Not Affected |
+/// | Subtraction   | Not Affected |
+/// | Half-Carry    | Not Affected |
+/// | Carry         | Not Affected |
+///
+/// # Examples
+/// ```rs
+/// Load16ImmediateOperation(Register::BC)
+/// ```
+///
+/// # Errors
+/// - The operation will fail if provided an 8-bit register
 #[derive(Debug)]
 pub struct Load16ImmediateOperation(pub Register);
 

--- a/ferroboy/src/operations/load8.rs
+++ b/ferroboy/src/operations/load8.rs
@@ -1,10 +1,43 @@
+use crate::assembly::{AssemblyInstruction, AssemblyInstructionBuilder};
 use crate::helpers::word_to_u16;
 use crate::operations::Operation;
 use crate::state::State;
 use crate::system::Register;
 
+// ? Should this be split up into separate files?
+
+/// Loads an immediate 8-bit value into a register.
+///
+/// # Opcode Reference
+/// ## Assembly definition
+/// ```a
+/// LD A,#
+/// ```
+///
+/// ## Runtime
+/// | Metric | Size |
+/// |:-------|:-----|
+/// | Length | 2    |
+/// | Cycles | 8    |
+///
+/// ## Flags
+/// | Flag          | Value        |
+/// |:--------------|:-------------|
+/// | Zero          | Not Affected |
+/// | Subtraction   | Not Affected |
+/// | Half-Carry    | Not Affected |
+/// | Carry         | Not Affected |
+///
+/// # Examples
+/// ```rs
+/// Load8ImmediateOperation(Register::A)
+/// ```
+///
+/// # Errors
+/// - The operation may fail if provided a 16-bit register
 #[derive(Debug)]
 pub struct Load8ImmediateOperation(pub Register);
+// FIXME: Register refactor
 
 impl Operation for Load8ImmediateOperation {
     fn act(&self, state: &mut State) -> crate::Result<()> {
@@ -15,8 +48,40 @@ impl Operation for Load8ImmediateOperation {
     }
 }
 
+// TODO: Implement Disassemble
+
+/// Copy the value of one register to another.
+///
+/// # Opcode Reference
+/// ## Assembly definition
+/// ```a
+/// LD A,B
+/// ```
+///
+/// ## Runtime
+/// | Metric | Size |
+/// |:-------|:-----|
+/// | Length | 1    |
+/// | Cycles | 4    |
+///
+/// ## Flags
+/// | Flag          | Value        |
+/// |:--------------|:-------------|
+/// | Zero          | Not Affected |
+/// | Subtraction   | Not Affected |
+/// | Half-Carry    | Not Affected |
+/// | Carry         | Not Affected |
+///
+/// # Examples
+/// ```rs
+/// Load8RegisterCopyOperation(Register::A, Register::B)
+/// ```
+///
+/// # Errors
+/// - The operation may fail if provided a 16-bit register
 #[derive(Debug)]
 pub struct Load8RegisterCopyOperation(pub Register, pub Register);
+// FIXME: Register refactor
 
 impl Operation for Load8RegisterCopyOperation {
     fn act(&self, state: &mut State) -> crate::Result<()> {
@@ -27,6 +92,51 @@ impl Operation for Load8RegisterCopyOperation {
     }
 }
 
+impl core::convert::TryFrom<Load8RegisterCopyOperation> for AssemblyInstruction {
+    type Error = String;
+
+    fn try_from(value: Load8RegisterCopyOperation) -> Result<Self, Self::Error> {
+        AssemblyInstructionBuilder::new()
+            .with_command("LD")
+            .with_arg(value.0)
+            .with_arg(value.1)
+            .build()
+    }
+}
+
+// FIXME: This doesn't work for LD A,(C), LD A,(a8) or LD A,(a16)
+// ? Maybe a flag enum? Load8MemorySource with values Register, WideRegister, Immediate, WideImmediate?
+// FIXME: Metrics here are based as-implemented, but should be updated when impl is correct
+// e.g. LD A,(a16) is 3 bytes, 16 cycles vs LD A,(HL) at 1 byte 8 cycles
+/// Load an 8-bit value from the address stored in a 16-bit register.
+///
+/// # Opcode Reference
+/// ## Assembly definition
+/// ```a
+/// LD A,(HL)
+/// ```
+///
+/// ## Runtime
+/// | Metric | Size |
+/// |:-------|:-----|
+/// | Length | 1    |
+/// | Cycles | 8    |
+///
+/// ## Flags
+/// | Flag          | Value        |
+/// |:--------------|:-------------|
+/// | Zero          | Not Affected |
+/// | Subtraction   | Not Affected |
+/// | Half-Carry    | Not Affected |
+/// | Carry         | Not Affected |
+///
+/// # Examples
+/// ```rs
+/// Load8RegisterCopyOperation(Register::A, Register::B)
+/// ```
+///
+/// # Errors
+/// - The operation may fail if the first argument is a 16-bit register
 #[derive(Debug)]
 pub struct Load8FromMemoryOperation(pub Register, pub Register);
 
@@ -45,6 +155,44 @@ impl Operation for Load8FromMemoryOperation {
     }
 }
 
+// TODO: LD (HL),d8 (0x36)
+// TODO: LD (a16),SP (0x08)
+// TODO: LD (HL+,A) / LD (HL-),A
+// ? What are the plus and minus?
+
+// FIXME: Metrics here are based on implementation and should be fixed
+// FIXME: Doesn't support LD (a16),A
+/// Copies a value from a register to the address held in a register.
+///
+/// # Opcode Reference
+/// ## Assembly definition
+/// ```a
+/// LD (HL),A
+/// ```
+///
+/// ## Runtime
+/// | Metric | Size |
+/// |:-------|:-----|
+/// | Length | 1*   |
+/// | Cycles | 8*   |
+///
+/// `*`: `LD (C),A` (0xE2) is 2 bytes and 8 cycles.
+///
+/// ## Flags
+/// | Flag          | Value        |
+/// |:--------------|:-------------|
+/// | Zero          | Not Affected |
+/// | Subtraction   | Not Affected |
+/// | Half-Carry    | Not Affected |
+/// | Carry         | Not Affected |
+///
+/// # Examples
+/// ```rs
+/// Load8RegisterToMemoryOperation(Register::HL, Register::A)
+/// ```
+///
+/// # Errors
+/// - The operation may fail if a 16-bit register is provided as the source
 #[derive(Debug)]
 pub struct Load8RegisterToMemoryOperation(pub Register, pub Register);
 

--- a/ferroboy/src/operations/nop.rs
+++ b/ferroboy/src/operations/nop.rs
@@ -1,6 +1,27 @@
 use crate::operations::Operation;
 use crate::State;
 
+/// A non-operation.
+///
+/// # Opcode Reference
+/// ## Assembly definition
+/// ```a
+/// NOP
+/// ```
+///
+/// ## Runtime
+/// | Metric | Size |
+/// |:-------|:-----|
+/// | Length | 1    |
+/// | Cycles | 4    |
+///
+/// ## Flags
+/// | Flag          | Value        |
+/// |:--------------|:-------------|
+/// | Zero          | Not Affected |
+/// | Subtraction   | Not Affected |
+/// | Half-Carry    | Not Affected |
+/// | Carry         | Not Affected |
 #[derive(Debug)]
 pub struct NopOperation;
 

--- a/ferroboy/src/operations/operation.rs
+++ b/ferroboy/src/operations/operation.rs
@@ -1,5 +1,11 @@
 use crate::state::State;
 
+/// An action that can be taken on the system.
+///
+/// Operations should, ideally, encapsulate all the changes
+/// to the system that occur as the result of an instruction.
+/// This includes things like mutating registers, changing
+/// flags, writing to memory, etc.
 pub trait Operation: Sync + std::fmt::Debug {
     fn act(&self, state: &mut State) -> crate::Result<()>;
 }

--- a/ferroboy/src/state.rs
+++ b/ferroboy/src/state.rs
@@ -1,5 +1,9 @@
 use crate::system::{Cartridge, Config, Register, CPU, MMU};
 
+/// The current state of the emulation.
+///
+/// This struct serves as the overall wrapper for the emulation system
+/// and holds all the references to the various sub-systems.
 #[derive(Debug, Default)]
 pub struct State {
     pub config: Config,
@@ -77,6 +81,7 @@ pub struct StateBuilder {
 }
 
 impl StateBuilder {
+    #[deprecated]
     #[allow(clippy::new_without_default)]
     pub fn new() -> Self {
         Self {

--- a/ferroboy/src/system/cartridge.rs
+++ b/ferroboy/src/system/cartridge.rs
@@ -11,6 +11,11 @@ const CARTRIDGE_HEADER: [u8; 48] = [
     0xBB, 0xBB, 0x67, 0x63, 0x6E, 0x0E, 0xEC, 0xCC, 0xDD, 0xDC, 0x99, 0x9F, 0xBB, 0xB9, 0x33, 0x3E,
 ];
 
+/// An enum to express what memory mapper a cartridge is using.
+///
+/// This does include the unlicensed memory mappers, however that doesn't mean that
+/// these memory mappers will be fully supported. They are included the sake of
+/// completeness.
 #[repr(u8)]
 #[derive(Debug)]
 pub enum CartridgeType {
@@ -98,6 +103,11 @@ impl CartridgeType {
     }
 }
 
+// TODO: Re-examine the API of this struct.
+// ? Do all these fields need to be exposed?
+// ? Should this use a builder instead of `from_buffer`/`from_file`?
+// ? Should there be flags for colour/SGB compatibility?
+/// A Gameboy cartridge.
 pub struct Cartridge {
     pub title: String,
     pub cartridge_type: CartridgeType,

--- a/ferroboy/src/system/config.rs
+++ b/ferroboy/src/system/config.rs
@@ -1,3 +1,10 @@
+// ? Do these fields need to actually be exposed on the external interface?
+// Might be better off having pub get and pub(crate) set
+/// Configuration options for the emulation.
+///
+/// This should be used to configure how emulation is handled for a
+/// given context, e.g. in the case of libretro doing a full bootcheck
+/// is probably desireable, but a test harness might not care.
 #[derive(Clone, Debug)]
 pub struct Config {
     /// Whether or not to ensure that the ROM boots correctly like a

--- a/ferroboy/src/system/cpu.rs
+++ b/ferroboy/src/system/cpu.rs
@@ -1,6 +1,7 @@
 use crate::helpers::{u16_to_word, word_to_u16};
 use bitflags::bitflags;
 
+// FIXME: Replace with Register (8bit) and WideRegister (16bit)
 /// `Register` is an enum to help indicate which registers
 /// an operation should apply to.
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
@@ -120,11 +121,7 @@ pub struct CPU {
 }
 
 impl CPU {
-    pub fn new() -> Self {
-        Default::default()
-    }
-
-    pub fn get(&self, register: Register) -> Result<u8, String> {
+    pub(crate) fn get(&self, register: Register) -> Result<u8, String> {
         let selected = match register {
             Register::A => self.a,
             Register::B => self.b,
@@ -139,7 +136,7 @@ impl CPU {
         Ok(selected)
     }
 
-    pub fn get16(&self, register: Register) -> Result<u16, String> {
+    pub(crate) fn get16(&self, register: Register) -> Result<u16, String> {
         let selected = match register {
             Register::SP => self.sp,
             Register::PC => self.pc,
@@ -155,11 +152,11 @@ impl CPU {
         Ok(selected)
     }
 
-    pub fn set(&mut self, register: Register, value: u8) -> Result<u8, String> {
+    pub(crate) fn set(&mut self, register: Register, value: u8) -> Result<u8, String> {
         self.mutate(register, |_| value)
     }
 
-    pub fn mutate<F>(&mut self, register: Register, f: F) -> Result<u8, String>
+    pub(crate) fn mutate<F>(&mut self, register: Register, f: F) -> Result<u8, String>
     where
         F: FnOnce(&u8) -> u8,
     {
@@ -179,11 +176,11 @@ impl CPU {
         Ok(*selected)
     }
 
-    pub fn set16(&mut self, register: Register, value: u16) -> Result<u16, String> {
+    pub(crate) fn set16(&mut self, register: Register, value: u16) -> Result<u16, String> {
         self.mutate16(register, |_| value)
     }
 
-    pub fn mutate16<F>(&mut self, register: Register, f: F) -> Result<u16, String>
+    pub(crate) fn mutate16<F>(&mut self, register: Register, f: F) -> Result<u16, String>
     where
         F: FnOnce(&u16) -> u16,
     {
@@ -214,32 +211,32 @@ impl CPU {
         Ok(selected)
     }
 
-    // FIXME: Remove this annotation after implementing RET and friends
-    #[allow(dead_code)]
-    pub fn has_flag(&self, flag: Flags) -> bool {
+    pub(crate) fn has_flag(&self, flag: Flags) -> bool {
         self.f & flag == flag
     }
 
-    pub fn set_flag(&mut self, flag: Flags) {
+    pub(crate) fn set_flag(&mut self, flag: Flags) {
         self.f |= flag
     }
 
-    pub fn clear_flag(&mut self, flag: Flags) {
+    pub(crate) fn clear_flag(&mut self, flag: Flags) {
         self.f -= flag;
     }
 
-    pub fn increment_clock(&mut self, amount: u64) {
+    pub(crate) fn increment_clock(&mut self, amount: u64) {
         self.clock += amount;
     }
 
-    pub fn set_clock<F>(&mut self, f: F)
+    // FIXME: Should this be test-only?
+    #[allow(dead_code)]
+    pub(crate) fn set_clock<F>(&mut self, f: F)
     where
         F: FnOnce(&u64) -> u64,
     {
         self.clock = f(&self.clock)
     }
 
-    pub fn is_halted(&self) -> bool {
+    pub(crate) fn is_halted(&self) -> bool {
         self.halt
     }
 }

--- a/ferroboy/src/system/cpu.rs
+++ b/ferroboy/src/system/cpu.rs
@@ -7,14 +7,21 @@ use bitflags::bitflags;
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub enum Register {
     // 8bit
-    /// Register A is the 6502's accumulator.
+    /// The accumulator.
     A,
+    /// General purpose register
     B,
+    /// General purpose register
     C,
+    /// General purpose register
     D,
+    /// General purpose register
     E,
+    /// General purpose register
     F,
+    /// General purpose register
     H,
+    /// General purpose register
     L,
 
     // Computed 16bit
@@ -97,7 +104,7 @@ impl Default for Flags {
     }
 }
 
-/// An implementation of a Zilog Z80 DMG-01 variant
+/// An implementation of the Gameboy's LR35902 CPU.
 #[derive(Debug, Default)]
 pub struct CPU {
     halt: bool,
@@ -156,6 +163,7 @@ impl CPU {
         self.mutate(register, |_| value)
     }
 
+    #[deprecated]
     pub(crate) fn mutate<F>(&mut self, register: Register, f: F) -> Result<u8, String>
     where
         F: FnOnce(&u8) -> u8,
@@ -180,6 +188,7 @@ impl CPU {
         self.mutate16(register, |_| value)
     }
 
+    #[deprecated]
     pub(crate) fn mutate16<F>(&mut self, register: Register, f: F) -> Result<u16, String>
     where
         F: FnOnce(&u16) -> u16,

--- a/ferroboy/src/system/mmu.rs
+++ b/ferroboy/src/system/mmu.rs
@@ -1,10 +1,24 @@
 use std::ops::{Index, IndexMut};
 
+/// The Gameboy's memory mapper.
+///
+/// The Gameboy used memory-mapped hardware, meaning things like
+/// the cartridge, link cable, video memory, inputs, etc. were all
+/// mapped into the RAM at different offsets. This struct does much
+/// the same as the hardware version did, mapping the various memory
+/// addresses to the actual implementors.
 pub struct MMU {
     memory: [u8; 0x10000],
 }
 
+// TODO: instead of having a monolithic block of bytes, break this into structs
+// Ideally, each struct should have a single responsibility, e.g. GameLink would
+// handle the memory that was associated with the GameLink cable, and this class
+// would just defer to it for the appropriate memory range.
+
 impl MMU {
+    // TODO: Move this into Default
+    #[deprecated]
     pub fn new() -> Self {
         Self {
             memory: [0; 0x10000],

--- a/ferroboy/src/system/opcodes.rs
+++ b/ferroboy/src/system/opcodes.rs
@@ -7,6 +7,7 @@ use crate::system::Register;
 
 type OpCodeMap = BTreeMap<u8, &'static dyn Operation>;
 
+/// A compile-time map of opcodes to their Operations.
 pub static OPCODES: Lazy<OpCodeMap> = Lazy::new(|| {
     let mut map = BTreeMap::new();
 
@@ -24,6 +25,7 @@ pub static OPCODES: Lazy<OpCodeMap> = Lazy::new(|| {
     map
 });
 
+/// Leak an object reference so that it lives on for the life of the program.
 fn leak<T>(value: T) -> &'static T {
     Box::leak(Box::new(value))
 }

--- a/readme.md
+++ b/readme.md
@@ -42,5 +42,17 @@ A disassembler for DMG-01 ROMs that _attempts_ to output 6502 assembly.
 ### libferroboy (TODO)
 A set of C bindings for Ferroboy. Eventually.
 
+## Conventions
+### Comments
+There are a few different comment blocks used throughout the code that you might encounter:
+
+- `FIXME` directives are things that are known to be in need of cleanup work
+- `TODO`, as one might expect, are things that have yet to be done
+- `?` Indicates a question. This can range from a question about the state of code, or to elaborate an idea in another comment.
+
+### Nomenclature
+- `Wide` vs `Narrow`  
+    This refers to the divide between 8-bit (narrow) and 16-bit (wide) interfaces. In cases where both are handled, the "narrow" prefix may be omitted.
+
 
 [libretro]: https://www.libretro.com/


### PR DESCRIPTION
Because this project is meant to be a good learning resource, this should probably have good docs. As such, this PR should document all existing code (closing #23) and setup a workflow to publish the Rustdocs to GitHub Pages. Along the way, where it makes sense, implementations to allow the `Disassembly` trait on operations should also be added, to bring everything up to snuff.