### PR TITLE
API Fixes

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -46,7 +46,7 @@ jobs:
         uses: actions-rs/tarpaulin@v0.1.0
         with:
           version: latest
-          args: "-- --out-type Lcov --test-threads 1"
+          args: "-- --out Lcov --test-threads 1"
         if: matrix.os == 'ubuntu-latest' && matrix.rust == 'stable'
       - name: Upload to Coveralls
         uses: coverallsapp/github-action@v1.1.1

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -46,6 +46,7 @@ jobs:
         uses: actions-rs/tarpaulin@v0.1.0
         with:
           version: latest
+          out-type: Lcov
           args: "-- --test-threads 1"
         if: matrix.os == 'ubuntu-latest' && matrix.rust == 'stable'
       - name: Upload to Coveralls

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -46,8 +46,7 @@ jobs:
         uses: actions-rs/tarpaulin@v0.1.0
         with:
           version: latest
-          out-type: Lcov
-          args: "-- --test-threads 1"
+          args: "-- --out-type Lcov --test-threads 1"
         if: matrix.os == 'ubuntu-latest' && matrix.rust == 'stable'
       - name: Upload to Coveralls
         uses: coverallsapp/github-action@v1.1.1

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -41,18 +41,18 @@ jobs:
         with:
           command: test
           args: --verbose
-        if: ${{ matrix.os != 'ubuntu-latest' || matrix.rust != 'stable' }}
-      - name: Test
+        if: matrix.os != 'ubuntu-latest' || matrix.rust != 'stable'
+      - name: Tarpaulin
         uses: actions-rs/tarpaulin@v0.1.0
         with:
           version: "0.12.4"
           args: "-- --test-threads 1"
-        if: ${{ matrix.os == 'ubuntu-latest' && matrix.rust == 'stable' }}
+        if: matrix.os == 'ubuntu-latest' && matrix.rust == 'stable'
       - name: Upload to Coveralls
         uses: coverallsapp/github-action@v1.1.1
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
-        if: ${{ matrix.os == 'ubuntu-latest' && matrix.rust == 'stable' }}
+        if: matrix.os == 'ubuntu-latest' && matrix.rust == 'stable'
       - name: Build
         uses: actions-rs/cargo@v1
         with:

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -41,18 +41,6 @@ jobs:
         with:
           command: test
           args: --verbose
-        if: matrix.os != 'ubuntu-latest' || matrix.rust != 'stable'
-      - name: Tarpaulin
-        uses: actions-rs/tarpaulin@v0.1.0
-        with:
-          version: latest
-          args: "--out Lcov"
-        if: matrix.os == 'ubuntu-latest' && matrix.rust == 'stable'
-      - name: Upload to Coveralls
-        uses: coverallsapp/github-action@v1.1.1
-        with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-        if: matrix.os == 'ubuntu-latest' && matrix.rust == 'stable'
       - name: Build
         uses: actions-rs/cargo@v1
         with:

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -49,7 +49,7 @@ jobs:
           args: "-- --test-threads 1"
         if: ${{ matrix.os == 'ubuntu-latest' }}
       - name: Upload to Coveralls
-        uses: coverallsapp/github-actions@v1.1
+        uses: coverallsapp/github-action@v1.1
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
         if: ${{ matrix.os == 'ubuntu-latest' }}

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -41,6 +41,18 @@ jobs:
         with:
           command: test
           args: --verbose
+        if: ${{ matrix.os != 'ubuntu-latest' }}
+      - name: Test
+        uses: actions-rs/tarpaulin@v0.1
+        with:
+          version: "0.12.4"
+          args: "-- --test-threads 1"
+        if: ${{ matrix.os == 'ubuntu-latest' }}
+      - name: Upload to Coveralls
+        uses: coverallsapp/github-actions@v1.1
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+        if: ${{ matrix.os == 'ubuntu-latest' }}
       - name: Build
         uses: actions-rs/cargo@v1
         with:

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -45,7 +45,7 @@ jobs:
       - name: Tarpaulin
         uses: actions-rs/tarpaulin@v0.1.0
         with:
-          version: "0.12.4"
+          version: latest
           args: "-- --test-threads 1"
         if: matrix.os == 'ubuntu-latest' && matrix.rust == 'stable'
       - name: Upload to Coveralls

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -51,7 +51,7 @@ jobs:
       - name: Upload to Coveralls
         uses: coverallsapp/github-action@v1.1.1
         with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
         if: matrix.os == 'ubuntu-latest' && matrix.rust == 'stable'
       - name: Build
         uses: actions-rs/cargo@v1

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -46,7 +46,7 @@ jobs:
         uses: actions-rs/tarpaulin@v0.1.0
         with:
           version: latest
-          args: "-- --out Lcov --test-threads 1"
+          out-type: Lcov
         if: matrix.os == 'ubuntu-latest' && matrix.rust == 'stable'
       - name: Upload to Coveralls
         uses: coverallsapp/github-action@v1.1.1

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -43,13 +43,13 @@ jobs:
           args: --verbose
         if: ${{ matrix.os != 'ubuntu-latest' }}
       - name: Test
-        uses: actions-rs/tarpaulin@v0.1
+        uses: actions-rs/tarpaulin@v0.1.0
         with:
           version: "0.12.4"
           args: "-- --test-threads 1"
         if: ${{ matrix.os == 'ubuntu-latest' }}
       - name: Upload to Coveralls
-        uses: coverallsapp/github-action@v1.1
+        uses: coverallsapp/github-action@v1.1.1
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
         if: ${{ matrix.os == 'ubuntu-latest' }}

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -46,7 +46,7 @@ jobs:
         uses: actions-rs/tarpaulin@v0.1.0
         with:
           version: latest
-          out-type: Lcov
+          args: "--out Lcov"
         if: matrix.os == 'ubuntu-latest' && matrix.rust == 'stable'
       - name: Upload to Coveralls
         uses: coverallsapp/github-action@v1.1.1

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -41,18 +41,18 @@ jobs:
         with:
           command: test
           args: --verbose
-        if: ${{ matrix.os != 'ubuntu-latest' }}
+        if: ${{ matrix.os != 'ubuntu-latest' || matrix.rust != 'stable' }}
       - name: Test
         uses: actions-rs/tarpaulin@v0.1.0
         with:
           version: "0.12.4"
           args: "-- --test-threads 1"
-        if: ${{ matrix.os == 'ubuntu-latest' }}
+        if: ${{ matrix.os == 'ubuntu-latest' && matrix.rust == 'stable' }}
       - name: Upload to Coveralls
         uses: coverallsapp/github-action@v1.1.1
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
-        if: ${{ matrix.os == 'ubuntu-latest' }}
+        if: ${{ matrix.os == 'ubuntu-latest' && matrix.rust == 'stable' }}
       - name: Build
         uses: actions-rs/cargo@v1
         with:

--- a/ferroboy/src/assembly/instruction.rs
+++ b/ferroboy/src/assembly/instruction.rs
@@ -127,6 +127,7 @@ impl AssemblyInstructionBuilder {
         self
     }
 
+    #[allow(unused)]
     pub fn with_comment(mut self, arg: impl ToString) -> Self {
         self.comment.replace(arg.to_string());
         self

--- a/ferroboy/src/extensions.rs
+++ b/ferroboy/src/extensions.rs
@@ -10,13 +10,13 @@ pub trait HalfCarry {
 
 impl HalfCarry for u8 {
     fn half_carry(&self, other: Self) -> bool {
-        (self & 0xF) + (other & 0xF) & 0x10 == 0x10
+        ((self & 0xF) + (other & 0xF)) & 0x10 == 0x10
     }
 }
 
 impl HalfCarry for u16 {
     fn half_carry(&self, other: Self) -> bool {
-        (self & 0xFFF) + (other & 0xFFF) & 0x1000 == 0x1000
+        ((self & 0xFFF) + (other & 0xFFF)) & 0x1000 == 0x1000
     }
 }
 

--- a/ferroboy/src/extensions.rs
+++ b/ferroboy/src/extensions.rs
@@ -1,0 +1,140 @@
+/// Used to check if an ALU operation would trigger a half-carry.
+///
+/// The DMG-01 used a 4-bit ALU, meaning that operations were
+/// done nybble-by-nybble, leading to a carry flag for each nybble.
+/// Because Ferroboy needs to check this on multiple types, helper
+/// functions become bulky, so we've wrapped this up into a trait.
+pub trait HalfCarry {
+    fn half_carry(&self, other: Self) -> bool;
+}
+
+impl HalfCarry for u8 {
+    fn half_carry(&self, other: Self) -> bool {
+        (self & 0xF) + (other & 0xF) & 0x10 == 0x10
+    }
+}
+
+impl HalfCarry for u16 {
+    fn half_carry(&self, other: Self) -> bool {
+        (self & 0xFFF) + (other & 0xFFF) & 0x1000 == 0x1000
+    }
+}
+
+/// Used to check if an ALU operation would trigger a carry.
+///
+/// The DMG-01 used a 4-bit ALU, meaning that operations were
+/// done nybble-by-nybble, leading to a carry flag for each nybble.
+/// Because Ferroboy needs to check this on multiple types, helper
+/// functions became bulky, so we've wrapped this up into a trait.
+pub trait Carry {
+    fn carry(&self, other: Self) -> bool;
+}
+
+impl Carry for u8 {
+    fn carry(&self, other: Self) -> bool {
+        self.checked_add(other).is_none()
+    }
+}
+
+impl Carry for u16 {
+    fn carry(&self, other: Self) -> bool {
+        self.checked_add(other).is_none()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    mod half_carry {
+        use crate::extensions::HalfCarry;
+
+        mod for_u8 {
+            use super::*;
+
+            #[test]
+            fn it_checks_explicit_carry() {
+                assert!(0xFu8.half_carry(0xF));
+            }
+
+            #[test]
+            fn it_checks_implicit_carry() {
+                assert!(0x4u8.half_carry(0xF));
+            }
+
+            #[test]
+            fn it_checks_non_carry() {
+                assert!(!0x4u8.half_carry(0x3));
+            }
+        }
+
+        mod for_u16 {
+            use super::*;
+
+            #[test]
+            fn it_checks_explicit_carry() {
+                assert!(0xF00u16.half_carry(0xF00));
+            }
+
+            #[test]
+            fn it_checks_implicit_carry() {
+                assert!(0x400u16.half_carry(0xF00));
+            }
+
+            #[test]
+            fn it_checks_non_carry() {
+                assert!(!0x400u16.half_carry(0x300));
+            }
+        }
+    }
+
+    mod carry {
+        use crate::extensions::Carry;
+
+        mod for_u8 {
+            use super::*;
+
+            #[test]
+            fn it_checks_explicit_carry() {
+                assert!(0xF0u8.carry(0xF0));
+            }
+
+            #[test]
+            fn it_checks_implicit_carry() {
+                assert!(0x40u8.carry(0xC0));
+            }
+
+            #[test]
+            fn it_checks_non_carry() {
+                assert!(!0x80u8.carry(0x40));
+            }
+
+            #[test]
+            fn it_checks_simple_overflows() {
+                assert!(0xFFu8.carry(0x01));
+            }
+        }
+
+        mod for_u16 {
+            use super::*;
+
+            #[test]
+            fn it_checks_explicit_carry() {
+                assert!(0x8000u16.carry(0x8000));
+            }
+
+            #[test]
+            fn it_checks_implicit_carry() {
+                assert!(0x4000u16.carry(0xC000));
+            }
+
+            #[test]
+            fn it_checks_non_carry() {
+                assert!(!0x8000u16.carry(0x4000));
+            }
+
+            #[test]
+            fn it_checks_simple_overflows() {
+                assert!(0xFFFFu16.carry(0x0001));
+            }
+        }
+    }
+}

--- a/ferroboy/src/helpers.rs
+++ b/ferroboy/src/helpers.rs
@@ -23,17 +23,85 @@ pub fn u16_to_word(word: u16) -> (u8, u8) {
     (high, low)
 }
 
+/// The DMG-01 uses a 4-bit ALU, so 8-bit operations require two ALU
+/// operations, and as such does a carry-check on each nybble. The
+/// half-carry flag is set when a value is carried from bit 3 to bit 4.
+/// Rust doesn't give us a u4 type, so we'll use this function to check
+/// the half-carry on the u8 instead.
+pub(crate) fn check_half_carry(left_hand: u8, right_hand: u8) -> bool {
+    (left_hand & 0xF) + (right_hand & 0xF) & 0x10 == 0x10
+}
+
+/// Similar to the half-carry, because the DMG-01 uses a 4-bit ALU
+/// we need to check whether a bit it carried from bit 7 to bit 8
+/// so we can set the appropriate flags.
+pub(crate) fn check_carry(left_hand: u8, right_hand: u8) -> bool {
+    let half_carried = check_half_carry(left_hand, right_hand) as u8;
+
+    let lhs = u16::from(left_hand & 0xF0);
+    let rhs = u16::from(right_hand & 0xF0);
+    let add = u16::from(half_carried << 4);
+
+    lhs + rhs + add & 0x100 == 0x100
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
 
-    #[test]
-    fn it_converts_u8_pairs_to_u16() {
-        assert_eq!(0xBEEF, word_to_u16((0xBE, 0xEF)));
+    mod word_to_u16 {
+        use super::*;
+
+        #[test]
+        fn it_converts_u8_pairs_to_u16() {
+            assert_eq!(0xBEEF, word_to_u16((0xBE, 0xEF)));
+        }
     }
 
-    #[test]
-    fn it_converts_u16_to_u8_pairs() {
-        assert_eq!((0xBE, 0xEF), u16_to_word(0xBEEF));
+    mod u16_to_word {
+        use super::*;
+
+        #[test]
+        fn it_converts_u16_to_u8_pairs() {
+            assert_eq!((0xBE, 0xEF), u16_to_word(0xBEEF));
+        }
+    }
+
+    mod check_half_carry {
+        use super::*;
+
+        #[test]
+        fn it_checks_explicit_carry() {
+            assert!(check_half_carry(0b0011_1110, 0b0000_1111));
+        }
+
+        #[test]
+        fn it_checks_implicit_carry() {
+            assert!(check_half_carry(0b0010_0111, 0b0000_1111));
+        }
+
+        #[test]
+        fn it_checks_non_carry() {
+            assert!(!check_half_carry(0b0010_0011, 0b0000_0111));
+        }
+    }
+
+    mod check_carry {
+        use super::*;
+
+        #[test]
+        fn it_checks_explicit_carry() {
+            assert!(check_carry(0b1000_0000, 0b1000_0000));
+        }
+
+        #[test]
+        fn it_checks_implicit_carry() {
+            assert!(check_carry(0b1100_0000, 0b0110_0000));
+        }
+
+        #[test]
+        fn it_checks_non_carry() {
+            assert!(!check_carry(0b0010_0011, 0b0000_0111));
+        }
     }
 }

--- a/ferroboy/src/helpers.rs
+++ b/ferroboy/src/helpers.rs
@@ -23,28 +23,6 @@ pub fn u16_to_word(word: u16) -> (u8, u8) {
     (high, low)
 }
 
-/// The DMG-01 uses a 4-bit ALU, so 8-bit operations require two ALU
-/// operations, and as such does a carry-check on each nybble. The
-/// half-carry flag is set when a value is carried from bit 3 to bit 4.
-/// Rust doesn't give us a u4 type, so we'll use this function to check
-/// the half-carry on the u8 instead.
-pub(crate) fn check_half_carry(left_hand: u8, right_hand: u8) -> bool {
-    (left_hand & 0xF) + (right_hand & 0xF) & 0x10 == 0x10
-}
-
-/// Similar to the half-carry, because the DMG-01 uses a 4-bit ALU
-/// we need to check whether a bit it carried from bit 7 to bit 8
-/// so we can set the appropriate flags.
-pub(crate) fn check_carry(left_hand: u8, right_hand: u8) -> bool {
-    let half_carried = check_half_carry(left_hand, right_hand) as u8;
-
-    let lhs = u16::from(left_hand & 0xF0);
-    let rhs = u16::from(right_hand & 0xF0);
-    let add = u16::from(half_carried << 4);
-
-    lhs + rhs + add & 0x100 == 0x100
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -64,44 +42,6 @@ mod tests {
         #[test]
         fn it_converts_u16_to_u8_pairs() {
             assert_eq!((0xBE, 0xEF), u16_to_word(0xBEEF));
-        }
-    }
-
-    mod check_half_carry {
-        use super::*;
-
-        #[test]
-        fn it_checks_explicit_carry() {
-            assert!(check_half_carry(0b0011_1110, 0b0000_1111));
-        }
-
-        #[test]
-        fn it_checks_implicit_carry() {
-            assert!(check_half_carry(0b0010_0111, 0b0000_1111));
-        }
-
-        #[test]
-        fn it_checks_non_carry() {
-            assert!(!check_half_carry(0b0010_0011, 0b0000_0111));
-        }
-    }
-
-    mod check_carry {
-        use super::*;
-
-        #[test]
-        fn it_checks_explicit_carry() {
-            assert!(check_carry(0b1000_0000, 0b1000_0000));
-        }
-
-        #[test]
-        fn it_checks_implicit_carry() {
-            assert!(check_carry(0b1100_0000, 0b0110_0000));
-        }
-
-        #[test]
-        fn it_checks_non_carry() {
-            assert!(!check_carry(0b0010_0011, 0b0000_0111));
         }
     }
 }

--- a/ferroboy/src/lib.rs
+++ b/ferroboy/src/lib.rs
@@ -33,7 +33,7 @@ pub fn start(state: &mut State) -> Result<()> {
 /// In an ideal world, this should be done at the clock rate of the Gameboy, but technically
 /// can be done at any rate.
 pub fn tick(state: &mut State) -> Result<&'static dyn crate::operations::Operation> {
-    let address = state.cpu.get16(WideRegister::PC)?;
+    let address = state.cpu.get16(WideRegister::PC);
     let opcode = state.mmu[address];
 
     state.increment_program_counter()?;

--- a/ferroboy/src/lib.rs
+++ b/ferroboy/src/lib.rs
@@ -9,6 +9,7 @@ pub use crate::system::WideRegister;
 pub use crate::system::OPCODES;
 
 mod assembly;
+mod extensions;
 mod helpers;
 mod operations;
 mod state;

--- a/ferroboy/src/lib.rs
+++ b/ferroboy/src/lib.rs
@@ -20,10 +20,7 @@ pub type Result<T> = core::result::Result<T, String>;
 /// Prepare the system and start the emulation.
 pub fn start(state: &mut State) -> Result<()> {
     if let Some(_cart) = &state.cartridge {
-        return state
-            .map_cartridge()
-            .and(state.jump(0x0100))
-            .and_then(|_| Ok(()));
+        return state.map_cartridge().and(state.jump(0x0100)).map(|_| ());
     }
 
     Err("Cartridge not loaded!".into())
@@ -49,7 +46,7 @@ pub fn tick(state: &mut State) -> Result<&'static dyn crate::operations::Operati
             println!("\t{:?}", operation);
         }
 
-        operation.act(state).and_then(|_| Ok(*operation))
+        operation.act(state).map(|_| *operation)
     } else {
         Err(format!("Invalid opcode! PC: {}", opcode))
     }

--- a/ferroboy/src/operations/add16.rs
+++ b/ferroboy/src/operations/add16.rs
@@ -56,21 +56,21 @@ impl Operation for Add16Operation {
 
         state.cpu.clear_flag(Flags::SUBTRACTION);
 
-        let (upper_arg, lower_arg) = u16_to_word(state.cpu.get16(self.0)?);
+        let (upper_arg, lower_arg) = u16_to_word(state.cpu.get16(self.0));
         let upper_arg = upper_arg as u16;
         let lower_arg = lower_arg as u16;
 
-        let calculated_lower = u16::from(state.cpu.get(Register::L)?) + lower_arg;
-        state.cpu.set(Register::L, calculated_lower as u8)?;
+        let calculated_lower = u16::from(state.cpu.get(Register::L)) + lower_arg;
+        state.cpu.set(Register::L, calculated_lower as u8);
 
         if calculated_lower / 0xFF > 0 {
             state.cpu.set_flag(Flags::HALF_CARRY);
         }
 
         let calculated_upper =
-            u16::from(state.cpu.get(Register::H)?) + upper_arg + (calculated_lower / 0xFF);
+            u16::from(state.cpu.get(Register::H)) + upper_arg + (calculated_lower / 0xFF);
 
-        state.cpu.set(Register::H, calculated_upper as u8)?;
+        state.cpu.set(Register::H, calculated_upper as u8);
 
         if calculated_upper / 0xFF > 0 {
             state.cpu.set_flag(Flags::CARRY);
@@ -105,17 +105,17 @@ mod tests {
     #[test]
     fn it_adds_the_lower_byte() -> crate::Result<()> {
         let mut state = State::default();
-        state.cpu.set16(WideRegister::BC, 0x0010)?;
+        state.cpu.set16(WideRegister::BC, 0x0010);
 
         let op = Add16Operation(WideRegister::BC);
 
-        assert_eq!(0x00, state.cpu.get(Register::H).unwrap());
-        assert_eq!(0x00, state.cpu.get(Register::L).unwrap());
+        assert_eq!(0x00, state.cpu.get(Register::H));
+        assert_eq!(0x00, state.cpu.get(Register::L));
 
         op.act(&mut state).unwrap();
 
-        assert_eq!(0x00, state.cpu.get(Register::H).unwrap());
-        assert_eq!(0x10, state.cpu.get(Register::L).unwrap());
+        assert_eq!(0x00, state.cpu.get(Register::H));
+        assert_eq!(0x10, state.cpu.get(Register::L));
         assert!(!state.cpu.has_flag(Flags::HALF_CARRY));
         assert!(!state.cpu.has_flag(Flags::CARRY));
 
@@ -125,16 +125,16 @@ mod tests {
     #[test]
     fn it_adds_the_upper_byte() -> crate::Result<()> {
         let mut state = State::default();
-        state.cpu.set16(WideRegister::BC, 0x0F10)?;
+        state.cpu.set16(WideRegister::BC, 0x0F10);
         let op = Add16Operation(WideRegister::BC);
 
-        assert_eq!(0x00, state.cpu.get(Register::H).unwrap());
-        assert_eq!(0x00, state.cpu.get(Register::L).unwrap());
+        assert_eq!(0x00, state.cpu.get(Register::H));
+        assert_eq!(0x00, state.cpu.get(Register::L));
 
         op.act(&mut state).unwrap();
 
-        assert_eq!(0x0F, state.cpu.get(Register::H).unwrap());
-        assert_eq!(0x10, state.cpu.get(Register::L).unwrap());
+        assert_eq!(0x0F, state.cpu.get(Register::H));
+        assert_eq!(0x10, state.cpu.get(Register::L));
         assert!(!state.cpu.has_flag(Flags::HALF_CARRY));
         assert!(!state.cpu.has_flag(Flags::CARRY));
 
@@ -144,18 +144,18 @@ mod tests {
     #[test]
     fn it_sets_half_carry() -> crate::Result<()> {
         let mut state = State::default();
-        state.cpu.set(Register::L, 0xFF)?;
-        state.cpu.set(Register::C, 1)?;
+        state.cpu.set(Register::L, 0xFF);
+        state.cpu.set(Register::C, 1);
 
         let op = Add16Operation(WideRegister::BC);
 
-        assert_eq!(0x00, state.cpu.get(Register::H).unwrap());
-        assert_eq!(0xFF, state.cpu.get(Register::L).unwrap());
+        assert_eq!(0x00, state.cpu.get(Register::H));
+        assert_eq!(0xFF, state.cpu.get(Register::L));
 
         op.act(&mut state).unwrap();
 
-        assert_eq!(0x01, state.cpu.get(Register::H).unwrap());
-        assert_eq!(0x00, state.cpu.get(Register::L).unwrap());
+        assert_eq!(0x01, state.cpu.get(Register::H));
+        assert_eq!(0x00, state.cpu.get(Register::L));
         assert!(state.cpu.has_flag(Flags::HALF_CARRY));
         assert!(!state.cpu.has_flag(Flags::CARRY));
 
@@ -165,20 +165,20 @@ mod tests {
     #[test]
     fn it_sets_carry() -> crate::Result<()> {
         let mut state = State::default();
-        state.cpu.set16(WideRegister::HL, 0xFFFF)?;
-        state.cpu.set16(WideRegister::BC, 0x0001)?;
+        state.cpu.set16(WideRegister::HL, 0xFFFF);
+        state.cpu.set16(WideRegister::BC, 0x0001);
         let op = Add16Operation(WideRegister::BC);
 
-        state.cpu.set(Register::H, 0xFF).unwrap();
-        state.cpu.set(Register::L, 0xFF).unwrap();
+        state.cpu.set(Register::H, 0xFF);
+        state.cpu.set(Register::L, 0xFF);
 
-        assert_eq!(0xFF, state.cpu.get(Register::H).unwrap());
-        assert_eq!(0xFF, state.cpu.get(Register::L).unwrap());
+        assert_eq!(0xFF, state.cpu.get(Register::H));
+        assert_eq!(0xFF, state.cpu.get(Register::L));
 
         op.act(&mut state).unwrap();
 
-        assert_eq!(0x00, state.cpu.get(Register::H).unwrap());
-        assert_eq!(0x00, state.cpu.get(Register::L).unwrap());
+        assert_eq!(0x00, state.cpu.get(Register::H));
+        assert_eq!(0x00, state.cpu.get(Register::L));
         assert!(state.cpu.has_flag(Flags::HALF_CARRY));
         assert!(state.cpu.has_flag(Flags::CARRY));
 

--- a/ferroboy/src/operations/add16.rs
+++ b/ferroboy/src/operations/add16.rs
@@ -1,8 +1,8 @@
 use crate::assembly::{AssemblyInstruction, AssemblyInstructionBuilder, Disassemble};
-use crate::helpers::u16_to_word;
+use crate::extensions::{Carry, HalfCarry};
 use crate::operations::Operation;
 use crate::state::State;
-use crate::system::{Flags, Register, WideRegister};
+use crate::system::{Flags, WideRegister};
 
 /*
  * 0x09 is ADD HL,BC
@@ -26,16 +26,16 @@ use crate::system::{Flags, Register, WideRegister};
 /// ## Runtime
 /// | Metric | Size |
 /// |:-------|:-----|
-/// | Length | 1 |
-/// | Cycles | 8 |
+/// | Length | 1    |
+/// | Cycles | 8    |
 ///
 /// ## Flags
-/// | Flag | Value |
-/// |:-----|:------|
-/// | Zero | Not Affected |
-/// | Subtraction | 0 |
-/// | Half-Carry | Set |
-/// | Carry | Set |
+/// | Flag        | Value        |
+/// |:------------|:-------------|
+/// | Zero        | Not Affected |
+/// | Subtraction | 0            |
+/// | Half-Carry  | Set          |
+/// | Carry       | Set          |
 ///
 /// # Examples
 /// ```rs
@@ -54,27 +54,17 @@ impl Operation for Add16Operation {
             return Err("Cannot use PC in ADD".into());
         }
 
+        let target = state.cpu.get16(WideRegister::HL);
+        let source = state.cpu.get16(self.0);
+        let calculated = target.wrapping_add(source);
+
+        state.cpu.set16(WideRegister::HL, calculated);
+
         state.cpu.clear_flag(Flags::SUBTRACTION);
-
-        let (upper_arg, lower_arg) = u16_to_word(state.cpu.get16(self.0));
-        let upper_arg = upper_arg as u16;
-        let lower_arg = lower_arg as u16;
-
-        let calculated_lower = u16::from(state.cpu.get(Register::L)) + lower_arg;
-        state.cpu.set(Register::L, calculated_lower as u8);
-
-        if calculated_lower / 0xFF > 0 {
-            state.cpu.set_flag(Flags::HALF_CARRY);
-        }
-
-        let calculated_upper =
-            u16::from(state.cpu.get(Register::H)) + upper_arg + (calculated_lower / 0xFF);
-
-        state.cpu.set(Register::H, calculated_upper as u8);
-
-        if calculated_upper / 0xFF > 0 {
-            state.cpu.set_flag(Flags::CARRY);
-        }
+        state
+            .cpu
+            .set_flag_value(Flags::HALF_CARRY, target.half_carry(source));
+        state.cpu.set_flag_value(Flags::CARRY, target.carry(source));
 
         Ok(())
     }
@@ -93,6 +83,7 @@ impl Disassemble for Add16Operation {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::system::Register;
 
     #[test]
     fn it_disassembles_properly() {
@@ -103,86 +94,69 @@ mod tests {
     }
 
     #[test]
-    fn it_adds_the_lower_byte() -> crate::Result<()> {
+    fn it_adds_the_lower_byte() {
         let mut state = State::default();
         state.cpu.set16(WideRegister::BC, 0x0010);
-
-        let op = Add16Operation(WideRegister::BC);
 
         assert_eq!(0x00, state.cpu.get(Register::H));
         assert_eq!(0x00, state.cpu.get(Register::L));
 
-        op.act(&mut state).unwrap();
+        Add16Operation(WideRegister::BC).act(&mut state).unwrap();
 
         assert_eq!(0x00, state.cpu.get(Register::H));
         assert_eq!(0x10, state.cpu.get(Register::L));
         assert!(!state.cpu.has_flag(Flags::HALF_CARRY));
         assert!(!state.cpu.has_flag(Flags::CARRY));
-
-        Ok(())
     }
 
     #[test]
-    fn it_adds_the_upper_byte() -> crate::Result<()> {
+    fn it_adds_the_upper_byte() {
         let mut state = State::default();
         state.cpu.set16(WideRegister::BC, 0x0F10);
-        let op = Add16Operation(WideRegister::BC);
 
         assert_eq!(0x00, state.cpu.get(Register::H));
         assert_eq!(0x00, state.cpu.get(Register::L));
 
-        op.act(&mut state).unwrap();
+        Add16Operation(WideRegister::BC).act(&mut state).unwrap();
 
         assert_eq!(0x0F, state.cpu.get(Register::H));
         assert_eq!(0x10, state.cpu.get(Register::L));
         assert!(!state.cpu.has_flag(Flags::HALF_CARRY));
         assert!(!state.cpu.has_flag(Flags::CARRY));
-
-        Ok(())
     }
 
     #[test]
-    fn it_sets_half_carry() -> crate::Result<()> {
+    fn it_sets_half_carry() {
         let mut state = State::default();
-        state.cpu.set(Register::L, 0xFF);
-        state.cpu.set(Register::C, 1);
+        state.cpu.set(Register::H, 0b0000_1000);
+        state.cpu.set(Register::B, 0b0000_1000);
 
-        let op = Add16Operation(WideRegister::BC);
+        assert_eq!(0x08, state.cpu.get(Register::H));
+        assert_eq!(0x00, state.cpu.get(Register::L));
 
-        assert_eq!(0x00, state.cpu.get(Register::H));
-        assert_eq!(0xFF, state.cpu.get(Register::L));
+        Add16Operation(WideRegister::BC).act(&mut state).unwrap();
 
-        op.act(&mut state).unwrap();
-
-        assert_eq!(0x01, state.cpu.get(Register::H));
+        assert_eq!(0x10, state.cpu.get(Register::H));
         assert_eq!(0x00, state.cpu.get(Register::L));
         assert!(state.cpu.has_flag(Flags::HALF_CARRY));
         assert!(!state.cpu.has_flag(Flags::CARRY));
-
-        Ok(())
     }
 
     #[test]
-    fn it_sets_carry() -> crate::Result<()> {
+    fn it_sets_carry() {
         let mut state = State::default();
         state.cpu.set16(WideRegister::HL, 0xFFFF);
         state.cpu.set16(WideRegister::BC, 0x0001);
-        let op = Add16Operation(WideRegister::BC);
-
-        state.cpu.set(Register::H, 0xFF);
-        state.cpu.set(Register::L, 0xFF);
 
         assert_eq!(0xFF, state.cpu.get(Register::H));
         assert_eq!(0xFF, state.cpu.get(Register::L));
 
-        op.act(&mut state).unwrap();
+        Add16Operation(WideRegister::BC).act(&mut state).unwrap();
 
         assert_eq!(0x00, state.cpu.get(Register::H));
         assert_eq!(0x00, state.cpu.get(Register::L));
         assert!(state.cpu.has_flag(Flags::HALF_CARRY));
         assert!(state.cpu.has_flag(Flags::CARRY));
-
-        Ok(())
     }
 
     #[test]
@@ -192,6 +166,6 @@ mod tests {
 
         Add16Operation(WideRegister::BC).act(&mut state).unwrap();
 
-        assert_ne!(true, state.cpu.has_flag(Flags::SUBTRACTION));
+        assert!(!state.cpu.has_flag(Flags::SUBTRACTION));
     }
 }

--- a/ferroboy/src/operations/add8.rs
+++ b/ferroboy/src/operations/add8.rs
@@ -37,12 +37,12 @@ pub struct Add8Operation(pub Register, pub Register);
 
 impl Operation for Add8Operation {
     fn act(&self, state: &mut State) -> crate::Result<()> {
-        let value = state.cpu.get(self.1)?;
+        let value = state.cpu.get(self.1);
 
         state.cpu.clear_flag(Flags::SUBTRACTION);
 
         // FIXME: This probably shouldn't ever fail, revisit this
-        state.cpu.set(self.0, state.cpu.get(self.0)? + value)?;
+        state.cpu.set(self.0, state.cpu.get(self.0) + value);
 
         // TODO: H + C
 
@@ -77,8 +77,8 @@ mod tests {
     #[test]
     fn it_adds_two_registers() -> crate::Result<()> {
         let mut state = State::default();
-        state.cpu.set(Register::A, 0x10)?;
-        state.cpu.set(Register::B, 0x06)?;
+        state.cpu.set(Register::A, 0x10);
+        state.cpu.set(Register::B, 0x06);
 
         Add8Operation(Register::A, Register::B).act(&mut state)
     }

--- a/ferroboy/src/operations/inc16.rs
+++ b/ferroboy/src/operations/inc16.rs
@@ -1,9 +1,7 @@
-use core::convert::TryInto;
-
 use crate::assembly::{AssemblyInstruction, AssemblyInstructionBuilder, Disassemble};
 use crate::operations::Operation;
 use crate::state::State;
-use crate::system::{Flags, WideRegister};
+use crate::system::WideRegister;
 
 /// Increments a singular register.
 ///

--- a/ferroboy/src/operations/inc16.rs
+++ b/ferroboy/src/operations/inc16.rs
@@ -42,25 +42,25 @@ impl Operation for Inc16Operation {
     fn act(&self, state: &mut State) -> crate::Result<()> {
         match self.0 {
             WideRegister::PC | WideRegister::SP => {
-                state.cpu.set16(self.0, state.cpu.get16(self.0)? + 1)?;
+                state.cpu.set16(self.0, state.cpu.get16(self.0) + 1);
             }
             _ => {
                 let (high, low) = self.0.try_into()?;
 
-                let mut lower = u16::from(state.cpu.get(low)?);
+                let mut lower = u16::from(state.cpu.get(low));
                 lower += 1;
-                state.cpu.set(low, lower as u8)?;
+                state.cpu.set(low, lower as u8);
 
                 if lower / 0xFF > 0 {
                     state.cpu.set_flag(Flags::HALF_CARRY);
-                    let mut upper = u16::from(state.cpu.get(high)?);
+                    let mut upper = u16::from(state.cpu.get(high));
                     upper += 1;
 
                     if upper / 0xFF > 0 {
                         state.cpu.set_flag(Flags::CARRY);
                     }
 
-                    state.cpu.set(high, upper as u8)?;
+                    state.cpu.set(high, upper as u8);
                 }
             }
         };
@@ -98,13 +98,13 @@ mod tests {
         let mut state = State::default();
         let op = Inc16Operation(WideRegister::BC);
 
-        assert_eq!(0x00, state.cpu.get(Register::B).unwrap());
-        assert_eq!(0x00, state.cpu.get(Register::C).unwrap());
+        assert_eq!(0x00, state.cpu.get(Register::B));
+        assert_eq!(0x00, state.cpu.get(Register::C));
 
         op.act(&mut state).unwrap();
 
-        assert_eq!(0x00, state.cpu.get(Register::B).unwrap());
-        assert_eq!(0x01, state.cpu.get(Register::C).unwrap());
+        assert_eq!(0x00, state.cpu.get(Register::B));
+        assert_eq!(0x01, state.cpu.get(Register::C));
     }
 
     #[test]
@@ -112,15 +112,15 @@ mod tests {
         let mut state = State::default();
         let op = Inc16Operation(WideRegister::BC);
 
-        state.cpu.set(Register::C, 0xFF).unwrap();
+        state.cpu.set(Register::C, 0xFF);
 
-        assert_eq!(0x00, state.cpu.get(Register::B).unwrap());
-        assert_eq!(0xFF, state.cpu.get(Register::C).unwrap());
+        assert_eq!(0x00, state.cpu.get(Register::B));
+        assert_eq!(0xFF, state.cpu.get(Register::C));
 
         op.act(&mut state).unwrap();
 
-        assert_eq!(0x01, state.cpu.get(Register::B).unwrap());
-        assert_eq!(0x00, state.cpu.get(Register::C).unwrap());
+        assert_eq!(0x01, state.cpu.get(Register::B));
+        assert_eq!(0x00, state.cpu.get(Register::C));
         assert!(state.cpu.has_flag(Flags::HALF_CARRY));
     }
 
@@ -129,16 +129,16 @@ mod tests {
         let mut state = State::default();
         let op = Inc16Operation(WideRegister::BC);
 
-        state.cpu.set(Register::B, 0xFF).unwrap();
-        state.cpu.set(Register::C, 0xFF).unwrap();
+        state.cpu.set(Register::B, 0xFF);
+        state.cpu.set(Register::C, 0xFF);
 
-        assert_eq!(0xFF, state.cpu.get(Register::B).unwrap());
-        assert_eq!(0xFF, state.cpu.get(Register::C).unwrap());
+        assert_eq!(0xFF, state.cpu.get(Register::B));
+        assert_eq!(0xFF, state.cpu.get(Register::C));
 
         op.act(&mut state).unwrap();
 
-        assert_eq!(0x00, state.cpu.get(Register::B).unwrap());
-        assert_eq!(0x00, state.cpu.get(Register::C).unwrap());
+        assert_eq!(0x00, state.cpu.get(Register::B));
+        assert_eq!(0x00, state.cpu.get(Register::C));
         assert!(state.cpu.has_flag(Flags::HALF_CARRY));
         assert!(state.cpu.has_flag(Flags::CARRY));
     }

--- a/ferroboy/src/operations/inc8.rs
+++ b/ferroboy/src/operations/inc8.rs
@@ -38,11 +38,11 @@ pub struct Inc8Operation(pub Register);
 
 impl Operation for Inc8Operation {
     fn act(&self, state: &mut State) -> crate::Result<()> {
-        let mut temp = u16::from(state.cpu.get(self.0)?);
+        let mut temp = u16::from(state.cpu.get(self.0));
         temp += 1;
 
         // FIXME: Set flags as needed
-        state.cpu.set(self.0, temp as u8)?;
+        state.cpu.set(self.0, temp as u8);
         state.cpu.increment_clock(4);
 
         Ok(())
@@ -68,7 +68,7 @@ mod tests {
 
         Inc8Operation(Register::A).act(&mut state).unwrap();
 
-        assert_eq!(1, state.cpu.get(Register::A).unwrap());
+        assert_eq!(1, state.cpu.get(Register::A));
     }
 
     #[test]

--- a/ferroboy/src/operations/interrupts.rs
+++ b/ferroboy/src/operations/interrupts.rs
@@ -1,0 +1,92 @@
+use crate::{
+    operations::Operation, AssemblyInstruction, AssemblyInstructionBuilder, Disassemble, State,
+};
+
+#[derive(Clone, Copy, Debug)]
+pub struct DisableInterruptsOperation;
+
+impl Operation for DisableInterruptsOperation {
+    fn act(&self, state: &mut State) -> crate::Result<()> {
+        state.cpu.disable_interrupts();
+        state.cpu.increment_clock(4);
+
+        Ok(())
+    }
+}
+
+impl Disassemble for DisableInterruptsOperation {
+    fn disassemble(&self, _: &mut State) -> crate::Result<AssemblyInstruction> {
+        AssemblyInstructionBuilder::new().with_command("DI").build()
+    }
+}
+
+#[derive(Clone, Copy, Debug)]
+pub struct EnableInterruptsOperation;
+
+impl Operation for EnableInterruptsOperation {
+    fn act(&self, state: &mut State) -> crate::Result<()> {
+        state.cpu.enable_interrupts();
+        state.cpu.increment_clock(4);
+
+        Ok(())
+    }
+}
+
+impl Disassemble for EnableInterruptsOperation {
+    fn disassemble(&self, _: &mut State) -> crate::Result<AssemblyInstruction> {
+        AssemblyInstructionBuilder::new().with_command("EI").build()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    mod disable {
+        use super::*;
+
+        #[test]
+        fn it_disables_interrupts() {
+            let mut state = State::default();
+            assert!(state.cpu.interrupts_enabled());
+
+            DisableInterruptsOperation.act(&mut state).unwrap();
+
+            assert!(!state.cpu.interrupts_enabled());
+        }
+
+        #[test]
+        fn it_disassembles_correctly() {
+            let instruction = DisableInterruptsOperation
+                .disassemble(&mut State::default())
+                .unwrap();
+
+            assert_eq!("DI", instruction.to_string());
+        }
+    }
+
+    mod enable {
+        use super::*;
+
+        #[test]
+        fn it_enables_interrupts() {
+            let mut state = State::default();
+            state.cpu.disable_interrupts();
+
+            assert!(!state.cpu.interrupts_enabled());
+
+            EnableInterruptsOperation.act(&mut state).unwrap();
+
+            assert!(state.cpu.interrupts_enabled());
+        }
+
+        #[test]
+        fn it_disassembles_correctly() {
+            let instruction = EnableInterruptsOperation
+                .disassemble(&mut State::default())
+                .unwrap();
+
+            assert_eq!("EI", instruction.to_string());
+        }
+    }
+}

--- a/ferroboy/src/operations/jump.rs
+++ b/ferroboy/src/operations/jump.rs
@@ -99,7 +99,7 @@ pub struct JumpRelativeOperation(pub JumpRelativeFlag);
 impl Operation for JumpRelativeOperation {
     fn act(&self, state: &mut State) -> crate::Result<()> {
         let offset = state.read_byte()? as u16;
-        let program_counter = state.cpu.get16(WideRegister::PC)?;
+        let program_counter = state.cpu.get16(WideRegister::PC);
 
         match self.0 {
             JumpRelativeFlag::Nop => {
@@ -274,7 +274,7 @@ pub struct JumpPositionOperation(pub JumpPositionFlags);
 impl Operation for JumpPositionOperation {
     fn act(&self, state: &mut State) -> crate::Result<()> {
         if JumpPositionFlags::Register.eq(&self.0) {
-            let address = state.cpu.get16(WideRegister::HL)?;
+            let address = state.cpu.get16(WideRegister::HL);
             state.jump(address)?;
             state.cpu.increment_clock(4);
 

--- a/ferroboy/src/operations/load16.rs
+++ b/ferroboy/src/operations/load16.rs
@@ -39,7 +39,7 @@ pub struct Load16ImmediateOperation(pub WideRegister);
 impl Operation for Load16ImmediateOperation {
     fn act(&self, state: &mut State) -> crate::Result<()> {
         let word = word_to_u16(state.read_word()?);
-        state.cpu.set16(self.0, word)?;
+        state.cpu.set16(self.0, word);
         state.cpu.increment_clock(12);
 
         Ok(())
@@ -72,13 +72,13 @@ mod tests {
 
         let op = Load16ImmediateOperation(WideRegister::BC);
 
-        assert_eq!(0x00, state.cpu.get(Register::B).unwrap());
-        assert_eq!(0x00, state.cpu.get(Register::C).unwrap());
+        assert_eq!(0x00, state.cpu.get(Register::B));
+        assert_eq!(0x00, state.cpu.get(Register::C));
 
         op.act(&mut state).unwrap();
 
-        assert_eq!(0xBE, state.cpu.get(Register::B).unwrap());
-        assert_eq!(0xEF, state.cpu.get(Register::C).unwrap());
+        assert_eq!(0xBE, state.cpu.get(Register::B));
+        assert_eq!(0xEF, state.cpu.get(Register::C));
     }
 
     #[test]

--- a/ferroboy/src/operations/load8.rs
+++ b/ferroboy/src/operations/load8.rs
@@ -43,7 +43,7 @@ pub struct Load8ImmediateOperation(pub Register);
 impl Operation for Load8ImmediateOperation {
     fn act(&self, state: &mut State) -> crate::Result<()> {
         let value = state.read_byte()?;
-        state.cpu.set(self.0, value).map(|_| ())?;
+        state.cpu.set(self.0, value);
         state.cpu.increment_clock(8);
         Ok(())
     }
@@ -95,8 +95,8 @@ pub struct Load8RegisterCopyOperation(pub Register, pub Register);
 
 impl Operation for Load8RegisterCopyOperation {
     fn act(&self, state: &mut State) -> crate::Result<()> {
-        let value = state.cpu.get(self.1)?;
-        state.cpu.set(self.0, value).map(|_| ())?;
+        let value = state.cpu.get(self.1);
+        state.cpu.set(self.0, value);
         state.cpu.increment_clock(4);
         Ok(())
     }
@@ -152,12 +152,12 @@ impl Operation for Load8FromMemoryOperation {
     fn act(&self, state: &mut State) -> crate::Result<()> {
         let (high, low) = self.1.try_into()?;
 
-        let address_high = state.cpu.get(high)?;
-        let address_low = state.cpu.get(low)?;
+        let address_high = state.cpu.get(high);
+        let address_low = state.cpu.get(low);
         let address = word_to_u16((address_high, address_low));
         let value = state.mmu[address];
 
-        state.cpu.set(self.0, value).map(|_| ())?;
+        state.cpu.set(self.0, value);
         state.cpu.increment_clock(8);
         Ok(())
     }
@@ -224,11 +224,11 @@ pub struct Load8RegisterToMemoryOperation(pub Load8RegisterToMemoryTarget, pub R
 impl Operation for Load8RegisterToMemoryOperation {
     fn act(&self, state: &mut State) -> crate::Result<()> {
         let address = match self.0 {
-            Load8RegisterToMemoryTarget::WideRegister(r) => state.cpu.get16(r)?,
-            Load8RegisterToMemoryTarget::Register(r) => u16::from(state.cpu.get(r)?),
+            Load8RegisterToMemoryTarget::WideRegister(r) => state.cpu.get16(r),
+            Load8RegisterToMemoryTarget::Register(r) => u16::from(state.cpu.get(r)),
         };
 
-        let value = state.cpu.get(self.1)?;
+        let value = state.cpu.get(self.1);
         state.mmu[address] = value;
 
         state.cpu.increment_clock(8);
@@ -264,11 +264,11 @@ mod tests {
 
         let op = Load8ImmediateOperation(Register::B);
 
-        assert_eq!(0x00, state.cpu.get(Register::B).unwrap());
+        assert_eq!(0x00, state.cpu.get(Register::B));
 
         op.act(&mut state).unwrap();
 
-        assert_eq!(0xFE, state.cpu.get(Register::B).unwrap());
+        assert_eq!(0xFE, state.cpu.get(Register::B));
     }
 
     #[test]
@@ -276,15 +276,15 @@ mod tests {
         let mut state = State::default();
         let op = Load8RegisterCopyOperation(Register::B, Register::A);
 
-        state.cpu.set(Register::A, 0xFE).unwrap();
+        state.cpu.set(Register::A, 0xFE);
 
-        assert_eq!(0x00, state.cpu.get(Register::B).unwrap());
-        assert_eq!(0xFE, state.cpu.get(Register::A).unwrap());
+        assert_eq!(0x00, state.cpu.get(Register::B));
+        assert_eq!(0xFE, state.cpu.get(Register::A));
 
         op.act(&mut state).unwrap();
 
-        assert_eq!(0xFE, state.cpu.get(Register::B).unwrap());
-        assert_eq!(0xFE, state.cpu.get(Register::A).unwrap());
+        assert_eq!(0xFE, state.cpu.get(Register::B));
+        assert_eq!(0xFE, state.cpu.get(Register::A));
     }
 
     #[test]
@@ -293,14 +293,14 @@ mod tests {
         let op = Load8FromMemoryOperation(Register::B, WideRegister::HL);
 
         state.mmu.mutate(|mmu| mmu[0x5E50] = 0xFE);
-        state.cpu.set(Register::H, 0x5E).unwrap();
-        state.cpu.set(Register::L, 0x50).unwrap();
+        state.cpu.set(Register::H, 0x5E);
+        state.cpu.set(Register::L, 0x50);
 
-        assert_eq!(0x00, state.cpu.get(Register::B).unwrap());
+        assert_eq!(0x00, state.cpu.get(Register::B));
 
         op.act(&mut state).unwrap();
 
-        assert_eq!(0xFE, state.cpu.get(Register::B).unwrap());
+        assert_eq!(0xFE, state.cpu.get(Register::B));
     }
 
     #[test]
@@ -311,8 +311,8 @@ mod tests {
             Register::A,
         );
 
-        state.cpu.set16(WideRegister::PC, 0x5E50).unwrap();
-        state.cpu.set(Register::A, 0xBE).unwrap();
+        state.cpu.set16(WideRegister::PC, 0x5E50);
+        state.cpu.set(Register::A, 0xBE);
 
         assert_eq!(0x00, state.mmu[0x5E50]);
 

--- a/ferroboy/src/operations/mod.rs
+++ b/ferroboy/src/operations/mod.rs
@@ -10,6 +10,9 @@ pub use inc8::*;
 mod inc16;
 pub use inc16::*;
 
+mod interrupts;
+pub use interrupts::*;
+
 mod jump;
 pub use jump::*;
 

--- a/ferroboy/src/state.rs
+++ b/ferroboy/src/state.rs
@@ -14,7 +14,7 @@ pub struct State {
 
 impl State {
     pub(crate) fn read_byte(&mut self) -> crate::Result<u8> {
-        let pc = self.cpu.get16(WideRegister::PC)?;
+        let pc = self.cpu.get16(WideRegister::PC);
         let word = self.mmu[pc];
 
         self.increment_program_counter()?;
@@ -23,7 +23,7 @@ impl State {
     }
 
     pub(crate) fn read_word(&mut self) -> crate::Result<(u8, u8)> {
-        let mut pc = self.cpu.get16(WideRegister::PC)?;
+        let mut pc = self.cpu.get16(WideRegister::PC);
         let high = self.mmu[pc];
 
         pc = self.increment_program_counter()?;
@@ -37,13 +37,15 @@ impl State {
 
     // ? Should this be in state or somewhere else?
     pub(crate) fn increment_program_counter(&mut self) -> crate::Result<u16> {
-        self.cpu
-            .set16(WideRegister::PC, self.cpu.get16(WideRegister::PC)? + 1)
+        let new_pointer = self.cpu.get16(WideRegister::PC) + 1;
+        self.cpu.set16(WideRegister::PC, new_pointer);
+
+        Ok(new_pointer)
     }
 
     pub(crate) fn jump(&mut self, destination: u16) -> crate::Result<()> {
         // FIXME(berwyn): Validate jump target
-        self.cpu.set16(WideRegister::PC, destination)?;
+        self.cpu.set16(WideRegister::PC, destination);
 
         Ok(())
     }
@@ -111,26 +113,26 @@ mod tests {
     fn it_reads_a_byte() {
         let mut state = State::default();
 
-        state.cpu.set16(WideRegister::PC, 0x00).unwrap();
+        state.cpu.set16(WideRegister::PC, 0x00);
         state.mmu.mutate(|mmu| mmu[0x00] = 0xFE);
 
         let byte = state.read_byte().unwrap();
 
         assert_eq!(0xFE, byte);
-        assert_eq!(0x01, state.cpu.get16(WideRegister::PC).unwrap());
+        assert_eq!(0x01, state.cpu.get16(WideRegister::PC));
     }
 
     #[test]
     fn it_reads_a_word() {
         let mut state = State::default();
 
-        state.cpu.set16(WideRegister::PC, 0x00).unwrap();
+        state.cpu.set16(WideRegister::PC, 0x00);
         state.mmu.mutate(|mmu| mmu[0x00] = 0xBE);
         state.mmu.mutate(|mmu| mmu[0x01] = 0xEF);
 
         let word = state.read_word().unwrap();
 
         assert_eq!((0xBE, 0xEF), word);
-        assert_eq!(0x02, state.cpu.get16(WideRegister::PC).unwrap());
+        assert_eq!(0x02, state.cpu.get16(WideRegister::PC));
     }
 }

--- a/ferroboy/src/system/cpu.rs
+++ b/ferroboy/src/system/cpu.rs
@@ -8,7 +8,6 @@ use crate::helpers::{u16_to_word, word_to_u16};
 /// an operation should apply to.
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub enum Register {
-    // 8bit
     /// The accumulator.
     A,
     /// General purpose register
@@ -213,6 +212,7 @@ impl CPU {
         self.f & flag == flag
     }
 
+    #[allow(unused)]
     pub(crate) fn set_flag(&mut self, flag: Flags) {
         self.f |= flag
     }
@@ -234,7 +234,7 @@ impl CPU {
     }
 
     // FIXME: Should this be test-only?
-    #[allow(dead_code)]
+    #[allow(unused)]
     pub(crate) fn set_clock<F>(&mut self, f: F)
     where
         F: FnOnce(&u64) -> u64,
@@ -242,6 +242,7 @@ impl CPU {
         self.clock = f(&self.clock)
     }
 
+    #[allow(unused)]
     pub(crate) fn interrupts_enabled(&self) -> bool {
         self.interrupts_enabled
     }

--- a/ferroboy/src/system/cpu.rs
+++ b/ferroboy/src/system/cpu.rs
@@ -124,10 +124,10 @@ impl Default for Flags {
 }
 
 /// An implementation of the Gameboy's LR35902 CPU.
-#[derive(Debug, Default)]
+#[derive(Debug)]
 pub struct CPU {
-    halt: bool,
-    interrupt_mode_enabled: bool,
+    halted: bool,
+    interrupts_enabled: bool,
 
     clock: u64,
     f: Flags,
@@ -242,8 +242,43 @@ impl CPU {
         self.clock = f(&self.clock)
     }
 
+    pub(crate) fn interrupts_enabled(&self) -> bool {
+        self.interrupts_enabled
+    }
+
+    pub(crate) fn enable_interrupts(&mut self) {
+        self.interrupts_enabled = true;
+    }
+
+    pub(crate) fn disable_interrupts(&mut self) {
+        self.interrupts_enabled = false;
+    }
+
     pub(crate) fn is_halted(&self) -> bool {
-        self.halt
+        self.halted
+    }
+}
+
+impl Default for CPU {
+    fn default() -> Self {
+        Self {
+            halted: false,
+            interrupts_enabled: true,
+
+            clock: 0,
+            f: Flags::CLEAR,
+
+            a: 0,
+            b: 0,
+            c: 0,
+            d: 0,
+            e: 0,
+            h: 0,
+            l: 0,
+
+            sp: 0,
+            pc: 0,
+        }
     }
 }
 

--- a/ferroboy/src/system/cpu.rs
+++ b/ferroboy/src/system/cpu.rs
@@ -221,6 +221,14 @@ impl CPU {
         self.f -= flag;
     }
 
+    pub(crate) fn set_flag_value(&mut self, flag: Flags, value: bool) {
+        if value {
+            self.f |= flag;
+        } else {
+            self.f -= flag;
+        }
+    }
+
     pub(crate) fn increment_clock(&mut self, amount: u64) {
         self.clock += amount;
     }

--- a/ferroboy/src/system/opcodes.rs
+++ b/ferroboy/src/system/opcodes.rs
@@ -21,6 +21,7 @@ pub static OPCODES: Lazy<OpCodeMap> = Lazy::new(|| {
     load_rank_C_ops(&mut map);
     load_rank_D_ops(&mut map);
     load_rank_E_ops(&mut map);
+    load_rank_F_ops(&mut map);
 
     map
 });
@@ -292,4 +293,10 @@ fn load_rank_E_ops(map: &mut OpCodeMap) {
         0xE9,
         leak(JumpPositionOperation(JumpPositionFlags::Register)),
     );
+}
+
+#[allow(non_snake_case)] // 'F' is a hex number here, not a letter
+fn load_rank_F_ops(map: &mut OpCodeMap) {
+    map.insert(0xF3, leak(DisableInterruptsOperation));
+    map.insert(0xFB, leak(EnableInterruptsOperation));
 }


### PR DESCRIPTION
Cleaning up several API contracts, such as removing the `Result`s from the CPU's `add`/`add16`, since they shouldn't ever fail. This is in part because `Register` and `WideRegister` have been split up so that operations can make actual guarantees about their outcomes.